### PR TITLE
Avoid AttributeError resulting from Pytorch Lightning update

### DIFF
--- a/grok/training.py
+++ b/grok/training.py
@@ -47,7 +47,7 @@ class TrainableTransformer(LightningModule):
                         self.add_model_specific_args().
         """
         super().__init__()
-        self.hparams = hparams  # type: ignore
+        self.hparams.update(vars(hparams))  # type: ignore
         self.prepare_data()
 
         self.transformer = Transformer(


### PR DESCRIPTION
With the most recent version of pytorch lightning, assigning a value to self.hparams raises an AttributeError (see eg https://github.com/PyTorchLightning/pytorch-lightning/discussions/7525 ).